### PR TITLE
Add unit tests for fill_state argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,11 +30,13 @@ Suggests:
 Depends: 
     R (>= 4.1)
 Imports: 
-    dplyr (>= 1.0.7), 
-    tidyr (>= 1.1.0), 
-    tibble (>= 3.0.1), 
-    rlang, 
-    utils
+    dplyr (>= 1.0.7),
+    tidyr (>= 1.1.0),
+    tibble (>= 3.0.1),
+    rlang,
+    utils,
+    cli,
+    glue
 VignetteBuilder: 
     knitr
 Language: en-US

--- a/R/build_matrix.R
+++ b/R/build_matrix.R
@@ -68,7 +68,7 @@ build_matrix <- function(data, state_start = NULL, state_end = NULL,
   # Make sure the 'data' argument is a valid data frame
   if (!is.data.frame(data)) {
 
-    rlang::abort(
+    cli::cli_abort(
       paste0(
         "`data` argument must be a valid data frame, not an object of type:",
         class(data)
@@ -92,7 +92,7 @@ build_matrix <- function(data, state_start = NULL, state_end = NULL,
         "Multiple columns of type `factor` with the phrase \"start\" in the ",
         "column variable name were found in `data`"
       ) |>
-        rlang::abort()
+        cli::cli_abort()
 
     }
 
@@ -102,7 +102,7 @@ build_matrix <- function(data, state_start = NULL, state_end = NULL,
         "No columns of type `factor` with the phrase \"start\" in the column ",
         "variable name were found"
       ) |>
-        rlang::abort()
+        cli::cli_abort()
 
     }
 
@@ -113,7 +113,7 @@ build_matrix <- function(data, state_start = NULL, state_end = NULL,
       colnames(state_start_col),
       "` as the \'state_start\' column variable"
     ) |>
-      rlang::inform()
+      cli::cli_alert_info()
 
     state_start_sym <- colnames(state_start_col) |>
       rlang::sym()
@@ -142,7 +142,7 @@ build_matrix <- function(data, state_start = NULL, state_end = NULL,
         "Multiple columns of type `factor` with the phrase \"end\" in the ",
         "column variable name were found in `data`"
       ) |>
-        rlang::abort()
+        cli::cli_abort()
 
     }
 
@@ -152,7 +152,7 @@ build_matrix <- function(data, state_start = NULL, state_end = NULL,
         "No columns of type `factor` with the phrase \"end\" in the column ",
         "variable name were found"
       ) |>
-        rlang::abort()
+        cli::cli_abort()
 
     }
 
@@ -163,7 +163,7 @@ build_matrix <- function(data, state_start = NULL, state_end = NULL,
       colnames(state_end_col),
       "` as the \'state_end\' column variable"
     ) |>
-      rlang::inform()
+      cli::cli_alert_info()
 
     state_end_sym <- colnames(state_end_col) |>
       rlang::sym()
@@ -187,14 +187,14 @@ build_matrix <- function(data, state_start = NULL, state_end = NULL,
     # Throw error if there are multiple columns matching the above criteria
     if (ncol(metric_col) > 1) {
 
-        rlang::abort("Multiple columns of type `numeric` were found in `data`")
+        cli::cli_abort("Multiple columns of type `numeric` were found in `data`")
 
     }
 
     # Throw error if there are no columns matching the above criteria
     if (ncol(metric_col) == 0) {
 
-      rlang::abort("No columns of type `numeric` were found in `data`")
+      cli::cli_abort("No columns of type `numeric` were found in `data`")
 
     }
 
@@ -204,7 +204,7 @@ build_matrix <- function(data, state_start = NULL, state_end = NULL,
       colnames(metric_col),
       "` as the \'metric\' column variable"
     ) |>
-      rlang::inform()
+      cli::cli_alert_info()
 
     metric_sym <- colnames(metric_col) |>
       rlang::sym()

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -7,7 +7,7 @@ check_args <- function(data, percent, fill_state, verbose) {
   # Make sure the 'data' argument is a valid data frame
   if (!is.data.frame(data)) {
 
-    rlang::abort(
+    cli::cli_abort(
       paste0(
         "`data` argument must be a valid data frame, not an object of type:",
         class(data)
@@ -19,7 +19,7 @@ check_args <- function(data, percent, fill_state, verbose) {
   # Ensure the supplied `percent` argument is logical
   if (!is.logical(percent)) {
 
-    rlang::abort("`percent` argument must be logical TRUE/FALSE")
+    cli::cli_abort("`percent` argument must be logical TRUE/FALSE")
 
   }
 
@@ -40,7 +40,7 @@ check_args <- function(data, percent, fill_state, verbose) {
         "`fill_state` argument must be length-one value (of type `character`,",
         " `numeric`, or `factor`)"
       ) |>
-        rlang::abort()
+        cli::cli_abort()
 
     }
 
@@ -49,7 +49,7 @@ check_args <- function(data, percent, fill_state, verbose) {
   # Ensure the supplied `verbose` argument is logical
   if (!is.logical(verbose)) {
 
-    rlang::abort("`verbose` argument must be logical TRUE/FALSE")
+    cli::cli_abort("`verbose` argument must be logical TRUE/FALSE")
 
   }
 
@@ -72,12 +72,9 @@ coerce_factor <- function(data, state_name) {
     # to convert it to an ordered factor
     if (!is.ordered(state_vec)) {
 
-      paste0(
-        "Please consider converting `",
-        state_name,
-        "` to an ordered factor before passing it to `migrate()` to ensure ",
-        "that the rank-ordering in the final matrix displays correctly"
-      ) |> rlang::warn()
+      cli::cli_warn(
+        c("!" = glue::glue("Please consider converting `{ state_name }` to an ordered factor before passing it to `migrate()` to ensure that the rank-ordering in the final matrix displays correctly"))
+      )
 
     }
 
@@ -87,19 +84,13 @@ coerce_factor <- function(data, state_name) {
 
     # Print messages to console letting user know that variable is being
     # converted to type `factor`
-    paste0(
-      "Converting `",
-      state_name,
-      "` to type `factor`"
-    ) |> rlang::warn()
-
-    paste0(
-      "To ensure that your output is ordered correctly, convert the `",
-      state_name,
-      "` column variable in your data frame to an ordered factor before ",
-      " passing to `migrate()`"
-    ) |> rlang::warn()
-
+    cli::cli_warn(
+      c(
+        "!" = glue::glue("Converting `{ state_name }` to type `factor`"),
+        "!" = glue::glue("To ensure that your output is ordered correctly, convert the `{ state_name }` column variable in your data frame to an ordered factor before passing to `migrate()`")
+      )
+    )
+    
     data <- data |>
       dplyr::mutate("{ state_name }" := as.factor(state_vec))
 
@@ -123,7 +114,7 @@ check_times <- function(times, time_name) {
       length(times),
       " unique values were found"
     ) |>
-      rlang::abort()
+      cli::cli_abort()
 
   }
 
@@ -134,13 +125,12 @@ check_times <- function(times, time_name) {
 time_message <- function(times) {
 
   paste0(
-    "=== Migrating from: `",
+    "Migrating from ",
     times[1],
-    "` --> `",
-    times[2],
-    "` ==="
+    " to ",
+    times[2]
   ) |>
-    rlang::inform()
+    cli::cli_alert_info()
 
 }
 
@@ -153,13 +143,9 @@ drop_missing_timepoints <- function(data) {
   out <- data |>
     tidyr::drop_na()
 
-  paste0(
-    "Removed ",
-    (nrow(data) - nrow(out)),
-    " observations due to missingness or IDs only existing at one `time` ",
-    "value"
-  ) |>
-    rlang::warn()
+  cli::cli_warn(
+    c("!" = glue::glue("Removed { (nrow(data) - nrow(out)) } observations due to missingness or IDs only existing at one `time` value"))
+  )
 
   return(out)
 
@@ -320,14 +306,14 @@ migrate <- function(data, id, time, state,
     # Stop if the `metric` variable doesn't exist in the `data` data frame,
     if (!metric_name %in% colnames(data)) {
 
-      rlang::abort("`metric` argument must be an unquoted variable in `data`")
+      cli::cli_abort("`metric` argument must be an unquoted variable in `data`")
 
     }
 
     # Stop if the `metric` variable isn't numeric
     if (!is.numeric(data[[metric_name]])) {
 
-      rlang::abort("`metric` argument must be a numeric type variable in `data`")
+      cli::cli_abort("`metric` argument must be a numeric type variable in `data`")
 
     }
 
@@ -370,7 +356,7 @@ migrate <- function(data, id, time, state,
     
       n_missing <- n_missing_start + n_missing_end
 
-      fill_state_class_type <- ifelse(fill_state_is_new, "*new*", "*existing*")
+      fill_state_class_type <- ifelse(fill_state_is_new, "new", "existing")
 
       # Inform the user
       cli::cli_div(theme = list(ul = list(`margin-left` = 2, before = "")))

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ migrated_df <- migrate(
   time = date, 
   state = risk_rating, 
 )
-#> === Migrating from: `2020-06-30` --> `2020-09-30` ===
+#> Migrating from: `2020-06-30` to `2020-09-30`
 ```
 
 ``` r

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -673,7 +673,7 @@ test_that("migrate() outputs more rows when `fill_state` is a value that doesn't
 
 })
 
-test_that("migrate() sets the value defined in `fill_state` as the smallest factor level", {
+test_that("migrate() sets the value defined in `fill_state` as the greatest factor level", {
 
   migrated_data <- migrate(
     data = mock_credit_with_missing,

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -706,8 +706,8 @@ test_that("migrate() correctly informs missing timepoint migration", {
   )
 
   expect_true(any(grepl("30 IDs have a missing timepoint:", messages_new_class)))
-  expect_true(any(grepl("Migrating 20 IDs with missing end timepoint to \\*new\\* class 'NR'", messages_new_class)))
-  expect_true(any(grepl("Migrating 10 IDs with missing start timepoint from \\*new\\* class 'NR'", messages_new_class)))
+  expect_true(any(grepl("Migrating 20 IDs with missing end timepoint to new class 'NR'", messages_new_class)))
+  expect_true(any(grepl("Migrating 10 IDs with missing start timepoint from new class 'NR'", messages_new_class)))
 
   messages_existing_class <- testthat::capture_messages(
     migrate(
@@ -722,7 +722,7 @@ test_that("migrate() correctly informs missing timepoint migration", {
   )
 
   expect_true(any(grepl("30 IDs have a missing timepoint:", messages_existing_class)))
-  expect_true(any(grepl("Migrating 20 IDs with missing end timepoint to \\*existing\\* class 'CCC'", messages_existing_class)))
-  expect_true(any(grepl("Migrating 10 IDs with missing start timepoint from \\*existing\\* class 'CCC'", messages_existing_class)))
+  expect_true(any(grepl("Migrating 20 IDs with missing end timepoint to existing class 'CCC'", messages_existing_class)))
+  expect_true(any(grepl("Migrating 10 IDs with missing start timepoint from existing class 'CCC'", messages_existing_class)))
 
 })

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -388,3 +388,305 @@ test_that("migrate() coerces 'character'-type `state` columns to type 'factor'",
   )
 
 })
+
+## Tests for `fill_state` argument  ---------------------------------------
+
+# Create mock data with `customer_id` values that only exist at one timepoint.
+# In particular, `mock_credit_with_missing` has:
+# - 20 customers that have a value only in the first timepoint
+# - 10 customers that have a value only in the second timepoint
+mock_credit_with_missing <- mock_credit |> 
+  # Remove the first 10 rows
+  dplyr::slice(-(1:10)) |>
+  # Remove the last 20 rows
+  dplyr::slice(-((dplyr::n() - 19):dplyr::n()))
+
+test_that("migrate() doesn't remove customers with missing timepoints when `fill_state` is not NULL", {
+
+  migrate_counts_without_missing <- migrate(
+    data = mock_credit,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    verbose = FALSE
+  ) |> 
+    dplyr::pull(count) |> 
+    sum()
+
+  migrate_counts_with_missing <- migrate(
+    data = mock_credit_with_missing,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    fill_state = "NR",
+    verbose = FALSE
+  ) |> 
+    dplyr::pull(count) |> 
+    sum()
+
+  expect_equal(migrate_counts_without_missing, migrate_counts_with_missing)
+
+})
+
+test_that("migrate() removes customers with missing timepoints when `fill_state` is NULL", {
+
+  migrate_counts_without_fill_state <- suppressWarnings({
+    migrate(
+      data = mock_credit_with_missing,
+      time = date,
+      state = risk_rating,
+      id = customer_id,
+      percent = FALSE,
+      verbose = FALSE
+    ) |> 
+      dplyr::pull(count) |> 
+      sum()
+  }) 
+
+  migrate_counts_with_fill_state <- migrate(
+    data = mock_credit_with_missing,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    fill_state = "NR",
+    verbose = FALSE
+  ) |> 
+    dplyr::pull(count) |> 
+    sum()
+
+  expect_true(migrate_counts_without_fill_state < migrate_counts_with_fill_state)
+
+})
+
+test_that("migrate() uses the filler state defined in `fill_state`", {
+
+  fill1 <- migrate(
+    data = mock_credit_with_missing,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    fill_state = "NR",
+    verbose = FALSE
+  )
+
+  expect_true("NR" %in% fill1$risk_rating_start)
+  expect_true("NR" %in% fill1$risk_rating_end)
+
+  fill2 <- migrate(
+    data = mock_credit_with_missing,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    fill_state = "No Rating",
+    verbose = FALSE
+  )
+
+  expect_true("No Rating" %in% fill2$risk_rating_start)
+  expect_true("No Rating" %in% fill2$risk_rating_end)
+
+})
+
+test_that("migrate() assigns filler state correctly when `fill_state` is not NULL", {
+
+  migrated_data <- migrate(
+    data = mock_credit_with_missing,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    fill_state = "NR",
+    verbose = FALSE
+  )
+
+  n_missing_start <- migrated_data |> 
+    dplyr::count(risk_rating_start, wt = count) |> 
+    dplyr::filter(risk_rating_start == "NR") |> 
+    dplyr::pull(n)
+
+  n_missing_end <- migrated_data |> 
+    dplyr::count(risk_rating_end, wt = count) |> 
+    dplyr::filter(risk_rating_end == "NR") |> 
+    dplyr::pull(n)
+
+  # Recall that `mock_credit_with_missing` removed the first 10 and the last 20 rows
+  expect_true(n_missing_start == 10)
+  expect_true(n_missing_end == 20)
+
+})
+
+test_that("migrate() errors when `fill_state` is not a length one value", {
+
+  expect_error(
+    migrate(
+      data = mock_credit_with_missing,
+      time = date,
+      state = risk_rating,
+      id = customer_id,
+      percent = FALSE,
+      fill_state = c("NR", "No Rating"),
+      verbose = FALSE
+    ),
+    reg_exp = "`fill_state` argument must be length-one value (of type `character`, `numeric`, or `factor`)"
+  )
+
+})
+
+test_that("migrate() errors when `fill_state` is not of type `character`, `numeric` or `factor`", {
+
+  # Logical
+  expect_error(
+    migrate(
+      data = mock_credit_with_missing,
+      time = date,
+      state = risk_rating,
+      id = customer_id,
+      percent = FALSE,
+      fill_state = FALSE,
+      verbose = FALSE
+    ),
+    reg_exp = "`fill_state` argument must be length-one value (of type `character`, `numeric`, or `factor`)"
+  )
+
+  # Dataframe
+  expect_error(
+    migrate(
+      data = mock_credit_with_missing,
+      time = date,
+      state = risk_rating,
+      id = customer_id,
+      percent = FALSE,
+      fill_state = iris,
+      verbose = FALSE
+    ),
+    reg_exp = "`fill_state` argument must be length-one value (of type `character`, `numeric`, or `factor`)"
+  )
+
+})
+
+test_that("migrate() works when `fill_state` is of type `character`", {
+
+  migrated_data <- migrate(
+    data = mock_credit_with_missing,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    fill_state = "NR",
+    verbose = FALSE
+  )
+
+  expect_true(
+    inherits(migrated_data, "data.frame")
+  )
+
+})
+
+test_that("migrate() works when `fill_state` is of type `numeric`", {
+
+  migrated_data <- migrate(
+    data = mock_credit_with_missing,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    fill_state = 999,
+    verbose = FALSE
+  )
+
+  expect_true(
+    inherits(migrated_data, "data.frame")
+  )
+
+})
+
+test_that("migrate() works when `fill_state` is of type `factor`", {
+
+  migrated_data <- migrate(
+    data = mock_credit_with_missing,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    fill_state = as.factor("No Rating"),
+    verbose = FALSE
+  )
+
+  expect_true(
+    inherits(migrated_data, "data.frame")
+  )
+
+})
+
+test_that("migrate() works when `fill_state` is a value that already exists", {
+
+  migrated_data_without_missing <- migrate(
+    data = mock_credit,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    verbose = FALSE
+  )
+
+  migrated_data_with_missing <- migrate(
+    data = mock_credit_with_missing,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    fill_state = "CCC",
+    verbose = FALSE
+  )
+
+  expect_identical(nrow(migrated_data_without_missing), nrow(migrated_data_with_missing))
+  expect_identical(sum(migrated_data_without_missing$count),sum(migrated_data_with_missing$count))
+
+})
+
+test_that("migrate() outputs more rows when `fill_state` is a value that doesn't exist", {
+
+  migrated_data_without_missing <- migrate(
+    data = mock_credit,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    verbose = FALSE
+  )
+
+  migrated_data_with_missing <- migrate(
+    data = mock_credit_with_missing,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    fill_state = "NR",
+    verbose = FALSE
+  )
+
+  expect_true(nrow(migrated_data_without_missing) < nrow(migrated_data_with_missing))
+
+})
+
+test_that("migrate() sets the value defined in `fill_state` as the smallest factor level", {
+
+  migrated_data <- migrate(
+    data = mock_credit_with_missing,
+    time = date,
+    state = risk_rating,
+    id = customer_id,
+    percent = FALSE,
+    fill_state = "ABC",
+    verbose = FALSE
+  )
+
+  levels <- levels(migrated_data$risk_rating_start)
+
+  expect_identical("ABC", levels[length(levels)])
+
+})

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -690,3 +690,39 @@ test_that("migrate() sets the value defined in `fill_state` as the greatest fact
   expect_identical("ABC", levels[length(levels)])
 
 })
+
+test_that("migrate() correctly informs missing timepoint migration", {
+
+  messages_new_class <- testthat::capture_messages(
+    migrate(
+      data = mock_credit_with_missing,
+      time = date,
+      state = risk_rating,
+      id = customer_id,
+      percent = FALSE,
+      fill_state = "NR",
+      verbose = TRUE
+    )
+  )
+
+  expect_true(any(grepl("30 IDs have a missing timepoint:", messages_new_class)))
+  expect_true(any(grepl("Migrating 20 IDs with missing end timepoint to \\*new\\* class 'NR'", messages_new_class)))
+  expect_true(any(grepl("Migrating 10 IDs with missing start timepoint from \\*new\\* class 'NR'", messages_new_class)))
+
+  messages_existing_class <- testthat::capture_messages(
+    migrate(
+      data = mock_credit_with_missing,
+      time = date,
+      state = risk_rating,
+      id = customer_id,
+      percent = FALSE,
+      fill_state = "CCC",
+      verbose = TRUE
+    )
+  )
+
+  expect_true(any(grepl("30 IDs have a missing timepoint:", messages_existing_class)))
+  expect_true(any(grepl("Migrating 20 IDs with missing end timepoint to \\*existing\\* class 'CCC'", messages_existing_class)))
+  expect_true(any(grepl("Migrating 10 IDs with missing start timepoint from \\*existing\\* class 'CCC'", messages_existing_class)))
+
+})


### PR DESCRIPTION
This PR adds unit tests for `migrate()`'s `fill_state` argument.
Run `devtools::check()` and expect no error, no warnings and no notes.

Closes #12 