### PR TITLE
Add fill state documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Authors@R:
              family = "Millanes",
              role = "ctb",
              email = "imillanes@ketchbrookanalytics.com"))
-Description: Tools to help convert credit risk data at two time points
+Description: Tools to help convert credit risk data at two timepoints
     into traditional credit state migration (aka, "transition") matrices.
     At a higher level, 'migrate' is intended to help an analyst understand
     how risk moved in their credit portfolio over a time interval.

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -137,7 +137,7 @@ time_message <- function(times) {
 
 
 # Remove any NA values across all columns; this will drop observations found
-# at only a single time point, unless the `fill_state` argument is *not* NULL
+# at only a single timepoint, unless the `fill_state` argument is *not* NULL
 drop_missing_timepoints <- function(data) {
 
   out <- data |>
@@ -218,7 +218,7 @@ migrate_percent <- function(data, state_start_name, metric_name) {
 #'   to/from. If left null, `migrate()` will attempt to use the first column
 #'   variable from the data frame provided in the `data` argument.
 #' @param time The column variable of in the `data` data frame representing the
-#'   time point (e.g., a Date) of each observation; this column should contain
+#'   timepoint (e.g., a Date) of each observation; this column should contain
 #'   two unique values (migration from Time A to Time B)
 #' @param state The column variable of the `data` data frame argument that
 #'   contains the credit risk state values.
@@ -408,7 +408,7 @@ migrate <- function(data, id, time, state,
     )
 
   # Remove any NA values across all columns; this will drop observations found
-  # at only a single time point, unless the `fill_state` argument is *not* NULL
+  # at only a single timepoint, unless the `fill_state` argument is *not* NULL
   if (nrow(tidyr::drop_na(data)) < nrow(data)) {
 
     data <- drop_missing_timepoints(data)

--- a/README.Rmd
+++ b/README.Rmd
@@ -61,9 +61,9 @@ devtools::install_github("mthomas-ketchbrook/migrate")
 
 ## Practical Usage
 
-{migrate} currently only handles transitions between exactly two (2) time points. Under the hood, {migrate} finds the earliest & latest dates in the given *time* variable, and filters out any observations where the *time* value does not match those two dates.
+`migrate()` currently only handles transitions between exactly two (2) timepoints. Under the hood, `migrate()` finds the earliest & latest dates in the given *time* variable, and filters out any observations where the *time* value does not match those two dates.
 
-If you are writing a SQL query to get data to be used with {migrate}, the query would likely look something like this:
+If you are writing a SQL query to get data to be used with `migrate()`, the query would likely look something like this:
 
 ```{r, eval = FALSE}
 # -- Get the *State* risk status and *Balance* dollar amount for each ID, at two distinct dates
@@ -72,6 +72,8 @@ If you are writing a SQL query to get data to be used with {migrate}, the query 
 # FROM my_database
 # WHERE Date IN ('2020-12-31', '2021-06-30')
 ```
+
+By default, `migrate()` drops observations that belong to IDs found at a single timepoint. However, users can define a *filler state* so that IDs with a single timepoint are not removed but rather migrated from or to this *filler state*. This allows for more flexible handling of such data, ensuring that no information is lost during the migration process. Check [Handle IDs with observations at a single timepoint](articles/migrate.html#handle-ids-with-observations-at-a-single-timepoint) for more information.
 
 ## Example
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -111,7 +111,6 @@ migrated_df <- migrate(
   time = date, 
   state = risk_rating, 
 )
-
 head(migrated_df)
 ```
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ migrated_df <- migrate(
 ```
 
 ``` r
-
 head(migrated_df)
 #> # A tibble: 6 × 3
 #>   risk_rating_start risk_rating_end   prop

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ devtools::install_github("mthomas-ketchbrook/migrate")
 
 ## Practical Usage
 
-{migrate} currently only handles transitions between exactly two (2)
-time points. Under the hood, {migrate} finds the earliest & latest dates
-in the given *time* variable, and filters out any observations where the
-*time* value does not match those two dates.
+`migrate()` currently only handles transitions between exactly two (2)
+timepoints. Under the hood, `migrate()` finds the earliest & latest
+dates in the given *time* variable, and filters out any observations
+where the *time* value does not match those two dates.
 
-If you are writing a SQL query to get data to be used with {migrate},
+If you are writing a SQL query to get data to be used with `migrate()`,
 the query would likely look something like this:
 
 ``` r
@@ -81,6 +81,15 @@ the query would likely look something like this:
 # FROM my_database
 # WHERE Date IN ('2020-12-31', '2021-06-30')
 ```
+
+By default, `migrate()` drops observations that belong to IDs found at a
+single timepoint. However, users can define a *filler state* so that IDs
+with a single timepoint are not removed but rather migrated from or to
+this *filler state*. This allows for more flexible handling of such
+data, ensuring that no information is lost during the migration process.
+Check [Handle IDs with observations at a single
+timepoint](articles/migrate.html#handle-ids-with-observations-at-a-single-timepoint)
+for more information.
 
 ## Example
 
@@ -128,7 +137,7 @@ migrated_df <- migrate(
   time = date, 
   state = risk_rating, 
 )
-#> Migrating from: `2020-06-30` to `2020-09-30`
+#> ℹ Migrating from 2020-06-30 to 2020-09-30
 ```
 
 ``` r
@@ -149,9 +158,9 @@ To create the state migration matrix, use the `build_matrix()` function
 
 ``` r
 build_matrix(migrated_df)
-#> Using `risk_rating_start` as the 'state_start' column variable
-#> Using `risk_rating_end` as the 'state_end' column variable
-#> Using `prop` as the 'metric' column variable
+#> ℹ Using `risk_rating_start` as the 'state_start' column variable
+#> ℹ Using `risk_rating_end` as the 'state_end' column variable
+#> ℹ Using `prop` as the 'metric' column variable
 #>             AAA         AA          A        BBB         BB          B        CCC
 #> AAA 0.774193548 0.19354839 0.03225806 0.00000000 0.00000000 0.00000000 0.00000000
 #> AA  0.101123596 0.66292135 0.15730337 0.07865169 0.00000000 0.00000000 0.00000000

--- a/man/migrate.Rd
+++ b/man/migrate.Rd
@@ -30,7 +30,7 @@ to/from. If left null, \code{migrate()} will attempt to use the first column
 variable from the data frame provided in the \code{data} argument.}
 
 \item{time}{The column variable of in the \code{data} data frame representing the
-time point (e.g., a Date) of each observation; this column should contain
+timepoint (e.g., a Date) of each observation; this column should contain
 two unique values (migration from Time A to Time B)}
 
 \item{state}{The column variable of the \code{data} data frame argument that

--- a/vignettes/migrate.Rmd
+++ b/vignettes/migrate.Rmd
@@ -20,7 +20,7 @@ library(migrate)
 
 ## Using `migrate`
 
-This package is intended to serve as a set of tools to help convert credit risk data at two time points into traditional credit state migration (aka, "transition") matrices. At a higher level, `migrate` is intended to help an analyst understand how risk moved in their credit portfolio over a time interval.
+This package is intended to serve as a set of tools to help convert credit risk data at two timepoints into traditional credit state migration (aka, "transition") matrices. At a higher level, `migrate` is intended to help an analyst understand how risk moved in their credit portfolio over a time interval.
 
 ## Background
 

--- a/vignettes/migrate.Rmd
+++ b/vignettes/migrate.Rmd
@@ -90,3 +90,91 @@ mock_credit |>
     metric = principal_balance
   )
 ```
+
+## Handle IDs with observations at a single timepoint
+
+The following code creates a dataframe that features 500 customers with the following characteristics:
+
+- 470 customers have a value at both timepoints
+- 20 customers have a value only at the first timepoint
+- 10 customers have a value only at the second timepoint
+
+```{r}
+mock_credit_with_missing <- mock_credit |> 
+  # Remove the value at the first timepoint for 10 customers
+  dplyr::slice(-(1:10)) |>
+  # Remove the value at the last timepoint for 20 customers
+  dplyr::slice(-((dplyr::n() - 19):dplyr::n()))
+```
+
+Check that the new dataframe has information about 500 customers:
+
+```{r}
+# Number of unique customer_id values in mock_credit_with_missing
+dplyr::n_distinct(mock_credit_with_missing$customer_id)
+```
+
+By default, `migrate()` drops observations that belong to IDs found at a single timepoint. `migrate()` informs such behavior through a warning:
+
+```{r}
+migrated_data_without_fill_state <- mock_credit_with_missing |>
+  migrate(
+    id = customer_id, 
+    time = date, 
+    state = risk_rating, 
+    percent = FALSE, 
+    verbose = FALSE
+  )
+```
+
+Notice that only 470 customers have been migrated:
+
+```{r}
+migrated_data_without_fill_state |> 
+  dplyr::pull(count) |> 
+  sum()
+```
+
+You can use `migrate()`'s `fill_state` argument to ensure that no information is lost during the migration process. When a *filler state* value (e.g., a character string such as "No Rating" or "NR") is assigned to `fill_state`, IDs with a single timepoint are not removed but rather migrated from or to this *filler state*.
+
+When `verbose = TRUE` a message will provide additional information about the IDs with missing timepoints:
+
+```{r}
+migrated_data_with_fill_state <- mock_credit_with_missing |>
+  migrate(
+    id = customer_id, 
+    time = date, 
+    state = risk_rating,
+    fill_state = "No Rating",
+    percent = FALSE, 
+    verbose = TRUE
+  )
+```
+
+Check that 500 customers were migrated:
+
+```{r}
+migrated_data_with_fill_state |> 
+  dplyr::pull(count) |> 
+  sum()
+```
+
+So far we have been using `count` as the metric to easily determine the amount of customers that migrated in each scenario. The following code provides an example migration that leverages `principal_balance` as the metric:
+
+```{r}
+mock_credit_with_missing |>
+  migrate(
+    id = customer_id, 
+    time = date, 
+    state = risk_rating, 
+    metric = principal_balance, 
+    fill_state = "No Rating",
+    percent = FALSE, 
+    verbose = FALSE
+  ) |>
+  build_matrix(
+    state_start = risk_rating_start, 
+    state_end = risk_rating_end, 
+    metric = principal_balance
+  )
+```

--- a/vignettes/migrate.Rmd
+++ b/vignettes/migrate.Rmd
@@ -64,7 +64,6 @@ migrated_df <- migrate(
   time = date, 
   state = risk_rating, 
 )
-
 head(migrated_df)
 ```
 


### PR DESCRIPTION
List of Changes:
- Added a new section to migrate vignette that shows how to use `fill_state` argument (as well as a brief introduction on why one would like or need to use it).
- Added a comment on README that talks about the problem that `fill_state` addresses and added a reference to the section in migrate vignette.
- Changed {migrate} to `migrate()` in README Practical Usage section because I think that the function of the package (not the package itself) is the one that does what is described there.
- Made sure that we use "timepoint" instead of "time point" throughout the repo.

Test:
- Check that the website is created as expected (with links working as they should)